### PR TITLE
Prevent R from downgrading a matrix to a vector

### DIFF
--- a/R/hypervolume_thin.R
+++ b/R/hypervolume_thin.R
@@ -37,7 +37,7 @@ hypervolume_thin <- function(hv, factor=NULL, num.points=NULL)
   
   hv_out <- hv
   
-  hv_out@RandomPoints <- rp[sample(1:nrow(rp),nrow(rp)*factor),]
+  hv_out@RandomPoints <- rp[sample(1:nrow(rp),nrow(rp)*factor),,drop=FALSE]
   
   hv_out@PointDensity <- hv@PointDensity * factor
   


### PR DESCRIPTION
It happens when user use only one trait.