### PR TITLE
occupancy routine improved

### DIFF
--- a/R/find_optimal_occupancy_thin.R
+++ b/R/find_optimal_occupancy_thin.R
@@ -1,55 +1,55 @@
-find_optimal_occupancy_thin <- function(..., verbose = TRUE, sequence = seq(0, 1, 0.1), n = 10, res_type = "raw"){
-  
+find_optimal_occupancy_thin <- function(..., verbose = TRUE, sequence = seq(0, 1, 0.1), n = 10, res_type = "raw") {
+
   # get random state from global environment
   old_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+
+  on.exit(
+    {
+      # restore random state
+      if (!is.null(old_state)) {
+        assign(".Random.seed", old_state, envir = .GlobalEnv, inherits = FALSE)
+      }
+    },
+    add = TRUE
+  )
 
   store_list <- list()
   seq_expanded <- rep(sequence, each = n)
   seed_set <- rep(sample(1:(.Machine$integer.max), n), times = length(sequence))
-  
-  if(verbose){
+
+  if (verbose) {
     pb <- progress_bar$new(total = length(seed_set))
   }
-  
-  for(i in 1:length(seq_expanded)){
 
-    if(seq_expanded[i] == 0){
+  for (i in 1:length(seq_expanded)) {
+    if (seq_expanded[i] == 0) {
       temp <- hypervolume_n_occupancy(..., thin = FALSE, verbose = FALSE, print_log = TRUE, seed = seed_set[i])
     } else {
       temp <- hypervolume_n_occupancy(..., thin = TRUE, verbose = FALSE, quant.thin = seq_expanded[i], print_log = TRUE, seed = seed_set[i])
-      
     }
     store_list[[i]] <- read.table("log_occupancy.txt", header = TRUE)
-    
-    if(verbose){
+
+    if (verbose) {
       pb$tick()
     }
   }
-  
-  if(verbose){
+
+  if (verbose) {
     pb$terminate()
   }
-  
+
   res_fun <- sapply(store_list, function(x) sqrt(mean((x[, "input"] - x[, "re_computed"])^2)))
   res_fun <- data.frame(seed_set, seq_expanded, res_fun)
   colnames(res_fun) <- c("seed", "quant.thin", "rmse")
-  
-  if(identical(res_type, "raw")){
-    res_final <- res_fun[order(res_fun[,"rmse"]),]
+
+  if (identical(res_type, "raw")) {
+    res_final <- res_fun[order(res_fun[, "rmse"]), ]
   }
-  
-  if(identical(res_type, "summary")){
-    res_final <-   aggregate(rmse ~ quant.thin, res_fun, FUN = function(x) c(mn = median(x), sd = sd(x)))
-    
+
+  if (identical(res_type, "summary")) {
+    res_final <- aggregate(rmse ~ quant.thin, res_fun, FUN = function(x) c(mn = mean(x), sd = sd(x)))
   }
-  
-  # restore random state
-  if (!is.null(old_state)) {
-    assign(".Random.seed", old_state, envir = .GlobalEnv, inherits = FALSE)
-  }
-  
+
   rownames(res_final) <- NULL
   res_final
-  
-
 }

--- a/R/get_centroid.R
+++ b/R/get_centroid.R
@@ -1,19 +1,24 @@
-get_centroid <- function(hv)
-{
-  if (inherits(hv,"Hypervolume"))
-  {
-    result = apply(hv@RandomPoints,2,mean)
+get_centroid <- function(hv) {
+  if (inherits(hv, "Hypervolume")) {
+    if (grepl("occupancy", hv@Method)) {
+      warning("get_centroid is probably not the best choice for occupancy objects. Please consider get_centroid_weighted instead.")
+    }
+    result <- apply(hv@RandomPoints, 2, mean)
     names(result) <- dimnames(hv@RandomPoints)[[2]]
     return(result)
-  }
-  else if (inherits(hv,"HypervolumeList"))
-  {
-    result = (sapply(hv@HVList, function(x) { apply(x@RandomPoints,2,mean) }))
-    dimnames(result)[[2]] <- sapply(hv@HVList, function(x) {x@Name})
+  } else if (inherits(hv, "HypervolumeList")) {
+    method_list <- unique(unlist(lapply(hv@HVList, function(x) x@Method)))
+    if (any(grepl("occupancy", method_list))) {
+      warning("get_centroid is probably not the best choice for occupancy objects. Please consider get_centroid_weighted instead.")
+    }
+    result <- (sapply(hv@HVList, function(x) {
+      apply(x@RandomPoints, 2, mean)
+    }))
+    dimnames(result)[[2]] <- sapply(hv@HVList, function(x) {
+      x@Name
+    })
     return(t(result))
-  }
-  else
-  {
-    stop('Wrong class input.')
+  } else {
+    stop("Wrong class input.")
   }
 }

--- a/R/get_centroid_weighted.R
+++ b/R/get_centroid_weighted.R
@@ -1,68 +1,56 @@
-get_centroid_weighted <- function(hv)
-{
-  if (class(hv)=="Hypervolume")
-  {
-    # with the new Method n_overlap and n_overlap_test it makes sense to calculate 
+get_centroid_weighted <- function(hv) {
+  if (inherits(hv, "Hypervolume")) {
+    # with the new Method n_overlap and n_overlap_test it makes sense to calculate
     # weighted mean
-    if(identical(hv@Method, "n_occupancy") | identical(hv@Method, "n_occupancy_test")){
+    if (grepl("occupancy", hv@Method)) {
       # get RandomPoints, no need to remove zeroes because they are removed during hypervolume_n_occupancy
       # when classification is NULL
       ran_points <- hv@RandomPoints
       apply(ran_points, 2, function(x) weighted.mean(x, hv@ValueAtRandomPoints))
     } else {
-      stop("weighted centroids works for methods occupancy and occupany_test")
+      stop("weighted centroids works for methods n_occupancy and n_occupany_test")
     }
-    
-    
-  }
-  
-  else if (class(hv)=="HypervolumeList")
-  
-    { 
+  } else if (inherits(hv, "HypervolumeList")) {
     method_list <- unique(unlist(lapply(hv@HVList, function(x) x@Method)))
-    if(identical(method_list, "n_occupancy") | identical(method_list, "n_occupancy_test")){
-      
+    if (any(grepl("occupancy", method_list))) {
+
       # get data for each element of the HypervolumeList
-      
+
       # get RandomPoints
       ran_points <- lapply(hv@HVList, function(x) x@RandomPoints)
-      
+
       # get ValueAtRandomPoints
       value_at_random_points <- lapply(hv@HVList, function(x) x@ValueAtRandomPoints)
-      
+
       # get group labels
       group_name <- unlist(lapply(hv@HVList, function(x) x@Name))
-      
+
       # initialize an empty matrix to store the results
       result <- as.data.frame(matrix(NA, ncol = ncol(ran_points[[1]]), nrow = length(group_name)))
-      
+
       # remove zeroes from both RandomPoints and ValueAtRandomPoints and then calculate the weighted mean
       # remember, 0 are kept by hypervolume_n_occupancy because they simplify further calculations
-      
-      for(i in 1:length(ran_points)){
+
+      for (i in 1:length(ran_points)) {
         # remove coordinates where ValueAtRandomPoints is zero
-        temp_ran_points <- ran_points[[i]][value_at_random_points[[i]] > 0,]
-        
+        temp_ran_points <- ran_points[[i]][value_at_random_points[[i]] > 0, ]
+
         # remove ValueAtRandomPoints equal to 0
         temp_values <- value_at_random_points[[i]]
         temp_values <- temp_values[temp_values > 0]
-        
+
         # calculate weighted means for each column of RandomPoints
         result[i, ] <- apply(temp_ran_points, 2, function(x) weighted.mean(x, temp_values))
       }
-      
+
       # assign colnames and rownames to the result matrix
       colnames(result) <- colnames(ran_points[[1]])
       rownames(result) <- group_name
-      result
-      
+      as.matrix(result)
     } else {
-      stop("weighted centroids works for methods occupancy and occupancy_test")
+      stop("weighted centroids works for methods n_occupancy and n_occupancy_test")
     }
-    
-  }
-  else
-  {
-    stop('Wrong class input.')
+  } else {
+    stop("Wrong class input.")
   }
 }

--- a/R/get_occupancy_intersection_bootstrap.R
+++ b/R/get_occupancy_intersection_bootstrap.R
@@ -13,11 +13,11 @@ get_occupancy_intersection_bootstrap <- function(path, method = "n_wise", res_ty
   
   if(identical(method, "all")){
     
-    res <- lapply(file_ls, function(z) occupancy_to_intersection(readRDS(file.path(path, z)), method = "all"))
+    res <- lapply(file_ls, function(z) occupancy_to_intersection(readRDS(file.path(path, z)), method = "all", tol = tol))
     
     if(relative){
       res <- lapply(res, get_volume)
-      res_union <- lapply(file_ls, function(x)get_volume(occupancy_to_union(readRDS(file.path(path, x)))))
+      res_union <- lapply(file_ls, function(x)get_volume(occupancy_to_union(readRDS(file.path(path, x)), tol = tol)))
       res <- do.call(rbind, res)
       res_union <- do.call(c, res_union)
       res <- sweep(res, 1, res_union, "/")
@@ -42,18 +42,18 @@ get_occupancy_intersection_bootstrap <- function(path, method = "n_wise", res_ty
                                                                      skewness = skewness(x),
                                                                      kurtosis = kurtosis(x))))
       colnames(final_res) <- c("hypervolume", "mean", "sd", "min", "quantile_2.5", "median", "quantile_97.5", "max",
-                               "skweness", "kurtosis")
+                               "skewness", "kurtosis")
       final_res[, "hypervolume"] <- as.character(final_res[, "hypervolume"])
     }
   }
   
 
   if(identical(method, "n_wise")){
-    res <- lapply(file_ls, function(z) occupancy_to_intersection(readRDS(file.path(path, z)), method = "n_wise", m = m))
+    res <- lapply(file_ls, function(z) occupancy_to_intersection(readRDS(file.path(path, z)), method = "n_wise", m = m, tol = tol))
     
     if(relative){
       res <- lapply(res, get_volume)
-      res_union <- lapply(file_ls, function(x)get_volume(occupancy_to_union(readRDS(file.path(path, x)), method = "n_wise", m = 2)))
+      res_union <- lapply(file_ls, function(x)get_volume(occupancy_to_union(readRDS(file.path(path, x)), method = "n_wise", m = m, tol = tol)))
       res <- do.call(rbind, res)
       res_union <- do.call(rbind, res_union)
       res <- res / res_union
@@ -80,7 +80,7 @@ get_occupancy_intersection_bootstrap <- function(path, method = "n_wise", res_ty
                                                                      skewness = skewness(x),
                                                                      kurtosis = kurtosis(x))))
       colnames(final_res) <- c("comparison", "mean", "sd", "min", "quantile_2.5", "median", "quantile_97.5", "max",
-                               "skweness", "kurtosis")
+                               "skewness", "kurtosis")
       final_res[, "comparison"] <- gsub("_", " - ", final_res[, "comparison"])
     }
   }

--- a/R/get_occupancy_unshared_bootstrap.R
+++ b/R/get_occupancy_unshared_bootstrap.R
@@ -1,4 +1,4 @@
-get_occupancy_unshared_bootstrap <- function(path, method = "pairwise", res_type = "summary", relative = FALSE){
+get_occupancy_unshared_bootstrap <- function(path, method = "pairwise", res_type = "summary", relative = FALSE,  tol = 1e-10){
   
   if(! any(identical(res_type, "raw") | identical(res_type, "summary"))){
     stop("res_type must be raw or summary")
@@ -12,11 +12,11 @@ get_occupancy_unshared_bootstrap <- function(path, method = "pairwise", res_type
   
   if(identical(method, "all")){
     
-    res <- lapply(file_ls, function(z) occupancy_to_unshared(readRDS(file.path(path, z)), method = "all"))
+    res <- lapply(file_ls, function(z) occupancy_to_unshared(readRDS(file.path(path, z)), method = "all", tol = tol))
     
     if(relative){
       res <- lapply(res, get_volume)
-      res_union <- lapply(file_ls, function(x)get_volume(occupancy_to_union(readRDS(file.path(path, x)))))
+      res_union <- lapply(file_ls, function(x)get_volume(occupancy_to_union(readRDS(file.path(path, x)), method = "all", tol = tol)))
       res <- do.call(rbind, res)
       res_union <- do.call(c, res_union)
       res <- sweep(res, 1, res_union, "/")
@@ -42,13 +42,13 @@ get_occupancy_unshared_bootstrap <- function(path, method = "pairwise", res_type
                                                                      skewness = skewness(x),
                                                                      kurtosis = kurtosis(x))))
       colnames(final_res) <- c("hypervolume", "mean", "sd", "min", "quantile_2.5", "median", "quantile_97.5", "max",
-                               "skweness", "kurtosis")
+                               "skewness", "kurtosis")
       final_res[, "hypervolume"] <- as.character(final_res[, "hypervolume"])
     }
   }
   
   if(identical(method, "pairwise")){
-    res <- lapply(file_ls, function(z) occupancy_to_unshared(readRDS(file.path(path, z)), method = "all"))
+    res <- lapply(file_ls, function(z) occupancy_to_unshared(readRDS(file.path(path, z)), method = "all", tol = tol))
     res <- do.call(rbind, lapply(res, function(x) get_volume(x)))
     
     combn_hyper <-  readRDS(file.path(path, file_ls[1]))
@@ -65,7 +65,7 @@ get_occupancy_unshared_bootstrap <- function(path, method = "pairwise", res_type
     res <- combn_res
     
     if(relative){
-      res_union <- lapply(file_ls, function(z) get_volume(occupancy_to_union(readRDS(file.path(path, z)), method = "n_wise", m = 2)))
+      res_union <- lapply(file_ls, function(z) get_volume(occupancy_to_union(readRDS(file.path(path, z)), method = "n_wise", m = 2, tol = tol)))
       res_union <- do.call(rbind, res_union)
       res_union <- res_union[,match(colnames(res_union), colnames(res))]
       res <- res/res_union
@@ -87,7 +87,7 @@ get_occupancy_unshared_bootstrap <- function(path, method = "pairwise", res_type
                                                                      skewness = skewness(x),
                                                                      kurtosis = kurtosis(x))))
       colnames(final_res) <- c("comparison", "mean", "sd", "min", "quantile_2.5", "median", "quantile_97.5", "max",
-                               "skweness", "kurtosis")
+                               "skewness", "kurtosis")
       final_res[, "comparison"] <- gsub("_", " - ", final_res[, "comparison"])
     }
   }

--- a/R/get_occupancy_volume_bootstrap.R
+++ b/R/get_occupancy_volume_bootstrap.R
@@ -39,7 +39,7 @@ get_occupancy_volume_bootstrap <- function(path, method = "all", res_type = "raw
                                                                      skewness = skewness(x),
                                                                      kurtosis = kurtosis(x))))
       colnames(final_res) <- c("hypervolume", "mean", "sd", "min", "quantile_2.5", "median", "quantile_97.5", "max",
-                               "skweness", "kurtosis")
+                               "skewness", "kurtosis")
       final_res[, "hypervolume"] <- as.character(final_res[, "hypervolume"])
     }
     
@@ -63,7 +63,7 @@ get_occupancy_volume_bootstrap <- function(path, method = "all", res_type = "raw
       char_combn <- combn(colnames(res), 2, FUN = function(x) paste(x[1], x[2], sep = " - "))
       res_pairwise <- matrix(NA, ncol = 9, nrow = ncol(file_combn))
       colnames(res_pairwise) <- c("mean", "sd", "min", "quantile_2.5", "median", "quantile_97.5", "max",
-                                  "skweness", "kurtosis")
+                                  "skewness", "kurtosis")
       
       
       

--- a/R/get_relative_volume.R
+++ b/R/get_relative_volume.R
@@ -10,7 +10,7 @@ get_relative_volume <- function(hv_list, tol = 1e-10){
   if(length(hv_list@HVList) < 2){
     stop("At least two hypervolumes are needed for a relative volume")
   }
-
+  
   # check if hypervolumes method were built within the occupancy routine
   hyper_methods <- sapply(hv_list@HVList, function(x) x@Method)
 
@@ -24,7 +24,11 @@ get_relative_volume <- function(hv_list, tol = 1e-10){
   # get volume of the hyper list and try to reconstruct the volume of the union
   # the reconstruction is made for each hypervolume in the hypervolume list
   vols <- get_volume(hv_list)
-  all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+  #all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+  combine_vrp <- lapply(hv_list@HVList, function(x) x@ValueAtRandomPoints)
+  combine_vrp <- do.call(cbind, combine_vrp)
+  zeroes_check <- apply(combine_vrp, 1, function(x) sum(abs(x)))
+  all_length <- sum(zeroes_check != 0)
   i_length <- unlist(lapply(hv_list@HVList, function(z) sum(z@ValueAtRandomPoints != 0)))
   all_vol <- vols*all_length/i_length
 

--- a/R/hypervolume_n_occupancy_test.R
+++ b/R/hypervolume_n_occupancy_test.R
@@ -13,6 +13,15 @@ hypervolume_n_occupancy_test <- function(observed, path, alternative = "two_side
     exists_cluster = FALSE
   }
   
+  on.exit({
+    # If a cluster was created for this specific function call, close cluster and register sequential backend
+    if(!exists_cluster) {
+      stopCluster(cl)
+      registerDoSEQ()
+    }
+  }, add = TRUE)
+  
+  
   # check if the first element of the first pairwise combination is called permutation1.rds
   # n <- list all the files in the first pa
 
@@ -256,12 +265,7 @@ hypervolume_n_occupancy_test <- function(observed, path, alternative = "two_side
     hv_list_res <- new("HypervolumeList", HVList = hv_list_res)
     result <- hv_list_res
   }
-  
-  if(!exists_cluster) {
-    stopCluster(cl)
-    registerDoSEQ()
-  }
-  
+
   return(result)
 
 }

--- a/R/hypervolume_plot.R
+++ b/R/hypervolume_plot.R
@@ -79,7 +79,7 @@ plot.HypervolumeList <- function(x,
   #### ALEX !!!!!! check the method, if n_occupancy remove any 0
   method_is_occupancy <- FALSE
   
-  if (class(x) == "Hypervolume")
+  if(inherits(x, "Hypervolume"))
   {
     # with the new Method n_overlap and n_overlap_test it makes sense to calculate 
     # weighted mean
@@ -92,7 +92,7 @@ plot.HypervolumeList <- function(x,
     }
   }
   
-  if (class(x)=="HypervolumeList"){
+  if(inherits(x, "HypervolumeList")){
     method_list <- unique(unlist(lapply(x@HVList, function(x) x@Method)))
     if(identical(method_list, "n_occupancy") | identical(method_list, "n_occupancy_test") | identical(method_list, "n_occupancy_permute") |
        identical(method_list, "occupancy_to_union") | identical(method_list, "occupancy_to_unshared") | identical(method_list, "occupancy_to_intersection")){
@@ -117,7 +117,7 @@ plot.HypervolumeList <- function(x,
   # remove the corresponding coordinates
   
   if(method_is_occupancy){
-    if(identical(class(x)[1], "HypervolumeList")){
+    if(inherits(x, "HypervolumeList")){
       for(i in 1:length(x@HVList)){
         hv_temp <- x@HVList[[i]]
         x@HVList[[i]]@RandomPoints <- hv_temp@RandomPoints[! is.na(hv_temp@ValueAtRandomPoints), ]

--- a/R/n_occupancy_function.R
+++ b/R/n_occupancy_function.R
@@ -21,6 +21,14 @@ n_occupancy_function <- function(hv_list, classification = NULL, method = "subsa
     set.seed(seed)
   }
   
+  on.exit({
+    # restore random state
+    if (!is.null(old_state)) {
+      assign(".Random.seed", old_state, envir = .GlobalEnv, inherits = FALSE)
+    }
+  })
+
+  
   # store some properties of the hypervolumes stored in hv_list:
   # dimensionality of random points, volume, density, names
   np_list <- unlist(lapply(hv_list@HVList, function(x) nrow(x@RandomPoints)))
@@ -506,11 +514,6 @@ n_occupancy_function <- function(hv_list, classification = NULL, method = "subsa
       result <- hv_list_res
     }
     
-  }
-  
-  # restore random state
-  if (!is.null(old_state)) {
-    assign(".Random.seed", old_state, envir = .GlobalEnv, inherits = FALSE)
   }
   
   result

--- a/R/occupancy_to_intersection.R
+++ b/R/occupancy_to_intersection.R
@@ -10,6 +10,7 @@ occupancy_to_intersection <- function(hv_list, method = "all", m = 2, tol = 1e-1
     stop("A HypervolumeList object is needed")
   }
   
+
   if(inherits(hv_list, "HypervolumeList")){
     
     # check construction method, it needs to be n_occupancy
@@ -23,7 +24,11 @@ occupancy_to_intersection <- function(hv_list, method = "all", m = 2, tol = 1e-1
       # get volume of the hyper list and try to reconstruct the volume of the union
       # the reconstruction is made for each hypervolume in the hypervolume list
       vols <- get_volume(hv_list)
-      all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      #all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      combine_vrp <- lapply(hv_list@HVList, function(x) x@ValueAtRandomPoints)
+      combine_vrp <- do.call(cbind, combine_vrp)
+      zeroes_check <- apply(combine_vrp, 1, function(x) sum(abs(x)))
+      all_length <- sum(zeroes_check != 0)
       i_length <- unlist(lapply(hv_list@HVList, function(z) sum(z@ValueAtRandomPoints != 0)))
       all_vol <- vols*all_length/i_length
       
@@ -67,7 +72,11 @@ occupancy_to_intersection <- function(hv_list, method = "all", m = 2, tol = 1e-1
       # get volume of the hyper list and try to reconstruct the volume of the union
       # the reconstruction is made for each hypervolume in the hypervolume list
       vols <- get_volume(hv_list)
-      all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      #all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      combine_vrp <- lapply(hv_list@HVList, function(x) x@ValueAtRandomPoints)
+      combine_vrp <- do.call(cbind, combine_vrp)
+      zeroes_check <- apply(combine_vrp, 1, function(x) sum(abs(x)))
+      all_length <- sum(zeroes_check != 0)
       i_length <- unlist(lapply(hv_list@HVList, function(z) sum(z@ValueAtRandomPoints != 0)))
       all_vol <- vols*all_length/i_length
       

--- a/R/occupancy_to_union.R
+++ b/R/occupancy_to_union.R
@@ -10,6 +10,7 @@ occupancy_to_union <- function(hv_list, method = "all", m = 2, tol = 1e-10){
     stop("A HypervolumeList object is needed")
   }
   
+
   if(inherits(hv_list, "HypervolumeList")){
     
     # check construction method, it needs to be n_occupancy
@@ -23,7 +24,11 @@ occupancy_to_union <- function(hv_list, method = "all", m = 2, tol = 1e-10){
       # get volume of the hyper list and try to reconstruct the volume of the union
       # the reconstruction is made for each hypervolume in the hypervolume list
       vols <- get_volume(hv_list)
-      all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      #all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      combine_vrp <- lapply(hv_list@HVList, function(x) x@ValueAtRandomPoints)
+      combine_vrp <- do.call(cbind, combine_vrp)
+      zeroes_check <- apply(combine_vrp, 1, function(x) sum(abs(x)))
+      all_length <- sum(zeroes_check != 0)
       i_length <- unlist(lapply(hv_list@HVList, function(z) sum(z@ValueAtRandomPoints != 0)))
       all_vol <- vols*all_length/i_length
       
@@ -66,7 +71,11 @@ occupancy_to_union <- function(hv_list, method = "all", m = 2, tol = 1e-10){
       # get volume of the hyper list and try to reconstruct the volume of the union
       # the reconstruction is made for each hypervolume in the hypervolume list
       vols <- get_volume(hv_list)
-      all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      #all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      combine_vrp <- lapply(hv_list@HVList, function(x) x@ValueAtRandomPoints)
+      combine_vrp <- do.call(cbind, combine_vrp)
+      zeroes_check <- apply(combine_vrp, 1, function(x) sum(abs(x)))
+      all_length <- sum(zeroes_check != 0)
       i_length <- unlist(lapply(hv_list@HVList, function(z) sum(z@ValueAtRandomPoints != 0)))
       all_vol <- vols*all_length/i_length
       

--- a/R/occupancy_to_unshared.R
+++ b/R/occupancy_to_unshared.R
@@ -10,6 +10,7 @@ occupancy_to_unshared <- function(hv_list, method = "all", tol = 1e-10){
     stop("A HypervolumeList object is needed")
   }
   
+
   if(inherits(hv_list, "HypervolumeList")){
     
     # check construction method, it needs to be n_occupancy
@@ -23,7 +24,11 @@ occupancy_to_unshared <- function(hv_list, method = "all", tol = 1e-10){
       # get volume of the hyper list and try to reconstruct the volume of the union
       # the reconstruction is made for each hypervolume in the hypervolume list
       vols <- get_volume(hv_list)
-      all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      #all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      combine_vrp <- lapply(hv_list@HVList, function(x) x@ValueAtRandomPoints)
+      combine_vrp <- do.call(cbind, combine_vrp)
+      zeroes_check <- apply(combine_vrp, 1, function(x) sum(abs(x)))
+      all_length <- sum(zeroes_check != 0)
       i_length <- unlist(lapply(hv_list@HVList, function(z) sum(z@ValueAtRandomPoints != 0)))
       all_vol <- vols*all_length/i_length
       
@@ -79,7 +84,11 @@ occupancy_to_unshared <- function(hv_list, method = "all", tol = 1e-10){
       # get volume of the hyper list and try to reconstruct the volume of the union
       # the reconstruction is made for each hypervolume in the hypervolume list
       vols <- get_volume(hv_list)
-      all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      #all_length <- length(hv_list@HVList[[1]]@ValueAtRandomPoints)
+      combine_vrp <- lapply(hv_list@HVList, function(x) x@ValueAtRandomPoints)
+      combine_vrp <- do.call(cbind, combine_vrp)
+      zeroes_check <- apply(combine_vrp, 1, function(x) sum(abs(x)))
+      all_length <- sum(zeroes_check != 0)
       i_length <- unlist(lapply(hv_list@HVList, function(z) sum(z@ValueAtRandomPoints != 0)))
       all_vol <- vols*all_length/i_length
       

--- a/man/find_optimal_occupancy_thin.Rd
+++ b/man/find_optimal_occupancy_thin.Rd
@@ -6,20 +6,20 @@
  Find optimal parameters to calculate occupancy
 }
 \description{
-The \code{find_optimal_occupancy_thin()} function is used to find the optimal parameters for \cr
+The \code{find_optimal_occupancy_thin()} function is used to find the optimal parameters for
 \code{hypervolume_n_occupancy()}.
 }
 \usage{
-  find_optimal_occupancy_thin(..., 
-                              verbose = TRUE, 
-                              sequence = seq(0, 1, 0.1), 
-                              n = 10, 
-                              res_type = "raw")
+find_optimal_occupancy_thin(..., 
+                            verbose = TRUE, 
+                            sequence = seq(0, 1, 0.1), 
+                            n = 10, 
+                            res_type = "raw")
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{...}{
-  Parameters to be used with \code{hypervolume_n_occupancy()}.
+  Parameters to be used to run \code{hypervolume_n_occupancy()}.
 }
   \item{verbose}{
 Logical value; print diagnostic output if \code{TRUE}.
@@ -28,15 +28,15 @@ Logical value; print diagnostic output if \code{TRUE}.
 Quantiles to be tested.
  }
   \item{n}{
-Number of iteration for each quantile.
+Number of seeds to be tested.
  }
    \item{res_type}{
-If \code{raw} prints seed, quantile and root mean square error (RMSE) for each iteration. If \code{summary} prints (RMSE) mean and standard deviation for each quantile.
+If \code{raw} print all the seeds and quantiles tested together with the resulting root mean square error (RMSE). If \code{summary} print RMSE mean and standard deviation for each quantile.
  }
  
 }
 \details{
-This function try to search for the optimal parameters to be used with \code{hypervolume_n_occupancy()}. It works by testing different quantiles and \code{n} seeds for random number generation (the same set of n seeds are tested for each quantile). RMSE is returned as the measure of the goodness of fit and results are ordered by increasing RMSE when \code{res_type = raw}. Quantile equal to 0 correspond to no thin. The obtained parameters can be used to feed arguments \code{quant.thin} and \code{seed} within the function \code{hypervolume_n_occupancy()}.
+The \code{find_optimal_occupancy_thin()} function searches for the optimal parameters for running \code{hypervolume_n_occupancy()}. It works by testing different quantiles and \code{n} seeds for random number generation (the same set of n seeds is tested for each quantile). RMSE is returned as the measure of the goodness of fit and results are ordered by increasing RMSE when \code{res_type = "raw"}. Quantile equal to 0 correspond to no thin. The obtained parameters can be used to feed arguments \code{quant.thin} and \code{seed} within the function \code{\link[=hypervolume_n_occupancy]{hypervolume_n_occupancy()}}.
 }
 \value{
 A \code{data.frame}.
@@ -67,16 +67,16 @@ hv_list = mapply(function(x, y)
 hv_list = hypervolume_join(hv_list)
 
 # find optimal parameters
-opt_par <- find_optimal_occupancy_thin(hv_list, 
+opt_par = find_optimal_occupancy_thin(hv_list, 
                                        classification = rep(c("female", "male"), 3),
                                        n = 20)
 
 head(opt_par)
 
-unoptimized_hv_occ <- hypervolume_n_occupancy(hv_list, 
+unoptimized_hv_occ = hypervolume_n_occupancy(hv_list, 
                         classification = rep(c("female", "male"), 3))
 
-optimized_hv_occ <- hypervolume_n_occupancy(hv_list, 
+optimized_hv_occ = hypervolume_n_occupancy(hv_list, 
                         classification = rep(c("female", "male"), 3), 
                         quant.thin = opt_par[1, 2], seed = opt_par[1, 1])
 

--- a/man/get_centroid_weighted.Rd
+++ b/man/get_centroid_weighted.Rd
@@ -2,10 +2,11 @@
 \alias{get_centroid_weighted}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-Get weighted centroid of hypervolume or hypervolume list.
+Get weighted centroid of hypervolume or hypervolume list
 }
 \description{
-Returns the column weighted mean of the random points in each hypervolume. Useful for hypervolumes generated with \code{hypervolume_n_occupancy} or \code{hypervolume_n_occupancy_test}.
+Returns the column weighted mean of the random points in each hypervolume. Useful for hypervolumes generated with \code{hypervolume_n_occupancy()}
+or \code{hypervolume_n_occupancy_test()}.
 }
 \usage{
 get_centroid_weighted(hv)
@@ -16,9 +17,18 @@ get_centroid_weighted(hv)
 A \code{Hypervolume} or \code{HypervolumeList} object.
 }
 }
+\details{
+The function \code{get_centroid_weighted()} differs from \code{get_centroid()} because it uses occupancy values to weight random points for evaluating centroids position.
+}
+
 \value{
 Either a vector or a matrix of column of centroid values along each axis. 
 }
+
+\seealso{
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_test}}
+}
+
 \examples{
 \dontrun{
 data(penguins,package='palmerpenguins')
@@ -33,8 +43,8 @@ hv_list = lapply(penguins_no_na_split, function(x)
   hypervolume_gaussian(x[, c("bill_length_mm","bill_depth_mm","flipper_length_mm")],
   samples.per.point=100))
 
-hv_list <- hypervolume_join(hv_list)
-hv_occupancy <- hypervolume_n_occupancy(hv_list)
+hv_list = hypervolume_join(hv_list)
+hv_occupancy = hypervolume_n_occupancy(hv_list)
 
 # unweighted centroids
 get_centroid(hv_occupancy)

--- a/man/get_occupancy_intersection_bootstrap.Rd
+++ b/man/get_occupancy_intersection_bootstrap.Rd
@@ -6,51 +6,52 @@
  Volume of the intersection of a bootstrapped occupancy object
 }
 \description{
-The \code{get_occupancy_intersection_bootstrap()} function is used to get the volume of the intersection of an object generated with \code{hypervolume_n_occupancy_bootstrap()}. It can provide raw values or summary statistics for both single groups or n_wise comparisons.
+The \code{get_occupancy_intersection_bootstrap()} function is used to get the volume of the intersection of objects generated with \code{hypervolume_n_occupancy_bootstrap()}. It provides raw values or summary statistics for all the hypervolumes or their n_wise combinations.
 }
 \usage{
-  get_occupancy_intersection_bootstrap(path,
-                                       method = "n_wise",
-                                       res_type = "summary",
-                                       m = 2, 
-                                       relative = FALSE,
-                                       tol = 1e-10)
+get_occupancy_intersection_bootstrap(path,
+                                     method = "n_wise",
+                                     res_type = "summary",
+                                     m = 2, 
+                                     relative = FALSE,
+                                     tol = 1e-10)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{path}{
-  A path to a directory of bootstrapped hypervolumes obtained with \cr
+  A path to a directory of bootstrapped occupancy objects obtained with \cr
   \code{hypervolume_n_occupancy_bootstrap()}.
 }
   \item{method}{
-If \code{all} the function compares the target hypervolume with all the hypervolumes in \code{path}. If \code{n_wise} it computes the intersection of each n_wise combination of hypervolumes in \code{path}.
+  If \code{all} compute the volume of the intersection among all the hypervolumes for each bootstrapped occupancy object found in \code{path}. If \code{n_wise} compute the volume of the intersection for each n_wise combination of hypervolumes within the bootstrapped occupancy objects found in \code{path}.
  }
   \item{res_type}{
   It can be \code{raw} or \code{pairwise}. See details.
 }
   \item{m}{
-Number of elements to choose. Default to 2 (pairwise comparisons). This argument is ignored when \code{method} is set to \code{all}.
+  Number of elements to choose. Default to 2 (pairwise comparisons). This argument is ignored when \code{method} is set to \code{all}.
  }
    \item{relative}{
   If \code{TRUE} it computes relative instead of absolute volumes.
 }
   \item{tol}{
-Set the tolerance for reconstructing whole volume.
+Set the tolerance for reconstructing whole volume. See details.
  }
 }
 
 \details{
-  The function \code{get_occupancy_intersection_bootstrap()} returns the volume of the intersection of bootstrapped hypervolumes if \code{res_type} is equal to \code{raw} and \code{method} to \code{all}. When \code{res_type} is equal to \code{summary} and method to \code{all} this function returns the mean volume as well as standard deviation, median, minimum, maximum and two quantiles of each group of the intersection. These summary statistics are calculated for among groups n_wise comparisons when \code{res_type} is equal to \code{summary} and \code{method} to \code{n_wise}.
+The function \code{get_occupancy_intersection_bootstrap()} returns the volume of the intersection for each bootstrapped occupancy object if \code{res_type = "raw"} and \code{method = "all"}. When \code{res_type = "summary"} and \code{method = "all"} this function returns the mean volume as well as the standard deviation, median, minimum, maximum, 2.5\% and 97.5\% quantiles, skewness and kurtosis of the intersection. The same summary statistics are calculated for each n_wise combination of hypervolumes when \code{res_type = "summary"} and \code{method = "n_wise"}. The number of elements of n_wise combinations is set with the argument \code{m}. The intersection is calculated by finding the set of random points shared by all or n_wise combinations of hypervolumes in each of the bootstrapped occupancy objects. More details on how the intersection is computed in \code{\link[=occupancy_to_intersection]{occupancy_to_intersection()}}. \cr
+The \code{get_occupancy_intersection_bootstrap()} function attempts to reconstruct the volume of the intersection from each bootstrapped occupancy object. At first, the volume of the union of hypervolumes is calculated for each hypervolume of the jth bootstrapped occupancy object as the ratio between the total number of random points and the number of random points of the ith hypervolume of the jth bootstrapped occupancy object, multiplied by the volume of the ith hypervolume of the jth bootstrapped occupancy object. This step results in a number of reconstructed volumes equal to the number of hypervolumes in the jth bootstrapped occupancy object. Reconstructed volumes are then compared among each other to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated using the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned. The volume of the intersection is then calculated as the ratio between the number of random points of the intersection and the total number of random points, multiplied by the volume of the union of hypervolumes. \cr
+When \code{relative = TRUE} relative instead of absolute volumes are returned. The relative volume is calculated as the ratio between the volume of the intersection and the volume of the union of all the hypervolumes (or combination of hypervolumes when \code{method = "n_wise"}). The same approach described above is used to reconstruct the volume of the union of hypervolumes.
 }
 
 \value{
-A \code{data.frame} with bootrapped volumes or summary statistics of intersection for single groups or pairwise comparisons.
+A \code{data.frame} with bootstrapped volumes or summary statistics of the intersection.
 }
 
 
 \seealso{
-\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \cr \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_union}}, \cr
-\code{\link{occupancy_to_unshared}} \code{\link{occupancy_filter}}
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \code{\link{occupancy_to_intersection}}
 }
 
 \examples{

--- a/man/get_occupancy_stats.Rd
+++ b/man/get_occupancy_stats.Rd
@@ -6,8 +6,8 @@
 Stats from occupancy objects
 }
 \description{
-Functions \code{get_occupancy_stats()} and \code{get_occupancy_stats_bootstrap()} return the results of a function applied to hypervolumes generated with \code{hypervolume_n_occupancy()}, \cr
-\code{hypervolume_n_occupancy_bootstrap()} or \code{hypervolume_n_occupancy_test()}.
+Functions \code{get_occupancy_stats()} and \code{get_occupancy_stats_bootstrap()} return the results of a function applied to hypervolumes generated with \code{hypervolume_n_occupancy()},
+\code{hypervolume_n_occupancy_bootstrap()}, \code{hypervolume_n_occupancy_permute()} or \code{hypervolume_n_occupancy_test()}.
 }
 \usage{
 get_occupancy_stats(hv, FUN, remove_zeroes = TRUE)
@@ -24,30 +24,29 @@ get_occupancy_stats_bootstrap(path,
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{hv}{
-  A \code{Hypervolume} or \code{HypervolumeList} object generated with \cr
-  \code{hypervolume_n_occupancy()} or \code{hypervolume_n_occupancy_test()}.
+  A \code{Hypervolume} or \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()}, \code{hypervolume_n_occupancy_bootstrap()}, \code{hypervolume_n_occupancy_permute()} or \code{hypervolume_n_occupancy_test()}.
 }
   \item{FUN}{
   The function to be applied.
 }
   \item{remove_zeroes}{
-  Remove zeroes before the calculation. See Details for further information.
+  Remove zeroes before the calculation. See Details.
 }
   \item{path}{
-  A path to a directory of bootstrapped hypervolumes obtained with \cr
+  A path to a directory of bootstrapped hypervolumes obtained with
   \code{hypervolume_n_occupancy_bootstrap()}.
 }
   \item{method}{
-  If \code{all} compares the target hypervolume with all the other hypervolume. If \code{pairwise} compare all the pairwise combinations of hypervolumes.
+  If \code{all} returns the results for each hypervolume. If \code{pairwise} returns the results for all the pairwise comparisons of individual hypervolumes.
 }
   \item{res_type}{
-  If \code{raw} returns the raw values obtained with \code{FUN}. If \code{summary} returns 
+  It can be \code{raw} or \code{pairwise}. See details.
 }
   \item{verbose}{
   Logical value; print diagnostic output if \code{TRUE}.
 }
   \item{cores}{
-  Number of logical cores to use while generating permuted hypervolumes. If parallel backend already registered to doParallel, function will use that backend and ignore the argument in cores.
+  Number of logical cores to use while generating permuted hypervolumes. If parallel backend already registered to \code{doParallel}, function will use that backend and ignore the argument in \code{cores}.
 }
 
 
@@ -57,14 +56,15 @@ Either a \code{vector}, a \code{matrix} or a \code{data.frame} with the results 
 }
 
 \details{
-These functions remove occupancy values equal to 0 by default. These values are generated
-during the occupancy routine when a random point is included 
-in some group of hypervolumes but not in others. A tipical usage of
+The \code{get_occupancy_stats()} and \code{get_occupancy_stats_bootstrap()} functions take \code{ValueAtRandomPoints} of each hypervolume as input to \code{FUN} (e.g. mean, median). \cr
+The \code{get_occupancy_stats_bootstrap()} function applies the function to bootstrapped occupancy objects generated with \code{hypervolume_n_occupancy_bootstrap()}. If \code{res_type = "raw"} raw values of the applied functions are returned for each occupancy object in \code{path}, only when \code{method = "all"}. If \code{res_type = "summary"} the mean value as well as the standard deviation, median, minimum, maximum, 2.5\% and 97.5\% quantiles, skewness and kurtosis are returned either for individual hypervolumes (\code{method = "all"}) or pairwise comparisons (\code{method = "pairwise"}). \cr
+The \code{get_occupancy_stats()} and \code{get_occupancy_stats_bootstrap()} functions remove occupancy values equal to 0 by default. These values are generated during the occupancy routine when a random point is included in some groups of hypervolumes but not in others. A tipical usage of
 \code{get_occupancy_stats()} or \code{get_occupancy_stats_bootstrap()} should remove zeroes before applying a function (the default).
 }
 
 \seealso{
-\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \cr \code{\link{hypervolume_n_occupancy_test}}
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}},
+\code{\link{hypervolume_n_occupancy_permute}}, \code{\link{hypervolume_n_occupancy_test}}
 }
 
 \examples{

--- a/man/get_occupancy_unshared_bootstrap.Rd
+++ b/man/get_occupancy_unshared_bootstrap.Rd
@@ -6,22 +6,23 @@
  Volume of the unshared fraction of a bootstrapped occupancy object
 }
 \description{
-The \code{get_occupancy_unshared_bootstrap()} function is used to get the volume of the unshared fraction of an object generated with \code{hypervolume_n_occupancy_bootstrap()}. It can provide raw values or summary statistics for both single groups or pairwise comparisons.
+The \code{get_occupancy_unshared_bootstrap()} function is used to get the volume of the unshared fraction of an object generated with \code{hypervolume_n_occupancy_bootstrap()}. It provides raw values or summary statistics for both individual hypervolumes or their pairwise comparisons.
 }
 \usage{
-  get_occupancy_unshared_bootstrap(path,
-                                       method = "pairwise",
-                                       res_type = "summary",
-                                       relative = FALSE)
+get_occupancy_unshared_bootstrap(path,
+                                 method = "pairwise",
+                                 res_type = "summary",
+                                 relative = FALSE,
+                                 tol = 1e-10)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{path}{
-  A path to a directory of bootstrapped hypervolumes obtained with \cr
+  A path to a directory of bootstrapped occupancy objects obtained with \cr
   \code{hypervolume_n_occupancy_bootstrap()}.
 }
   \item{method}{
-If \code{all} the function compares the target hypervolume with all the hypervolumes in \code{path}. If \code{pairwise} it computes the intersection of each n_wise combination of hypervolumes in \code{path}.
+If \code{all} compute the volume of the unique fraction of each hypervolume compared to all the hypervolumes for each occupancy object in \code{path}. If \code{pairwise} compute the difference of the volume of the unshared fraction for each pairwise combination of hypervolumes within the bootstrapped occupancy objects found in \code{path}.
  }
   \item{res_type}{
   It can be \code{raw} or \code{pairwise}. See details.
@@ -29,20 +30,25 @@ If \code{all} the function compares the target hypervolume with all the hypervol
   \item{relative}{
   If \code{TRUE} it computes relative instead of absolute volumes.
 }
+  \item{tol}{
+Set the tolerance for reconstructing whole volume. See details.
+ }
 }
 
 \details{
-  The function \code{get_occupancy_unshared_bootstrap()} returns the volume of the unshared fraction of bootstrapped hypervolumes if \code{res_type} is equal to \code{raw} and \code{method} to \code{all}. When \code{res_type} is equal to \code{summary} and method to \code{all} this function returns the mean volume as well as standard deviation, median, minimum, maximum and two quantiles of each group of the unshared fraction. These summary statistics are calculated for among groups n_wise comparisons when \code{res_type} is equal to \code{summary} and \code{method} to \code{pairwise}.
+The function \code{get_occupancy_unshared_bootstrap()} returns the volume of the unshared fraction for each hypervolume in the bootstrapped occupancy object if \code{res_type = "raw"} and \code{method = "all"}. When \code{res_type = "summary"} and \code{method = "all"} this function returns the mean volume as well as the standard deviation, median, minimum, maximum, 2.5\% and 97.5\% quantiles, skewness and kurtosis of the unshared fraction for each hypervolume. The same summary statistics are calculated for the difference of volume of the unshared fraction for each pairwise combination of hypervolumes when \code{res_type = "summary"} and \code{method = "pairwise"}. The unshared fraction is calculated by finding the set of random points that are not shared with other hypervolumes or pairwise combinations of hypervolumes in each bootstrapped occupancy object. More details on how the unshared fraction is computed in \code{\link[=occupancy_to_unshared]{occupancy_to_unshared()}}.\cr
+The \code{get_occupancy_unshared_bootstrap()} function attempts to reconstruct the volume of the unshared fraction from each bootstrapped occupancy object. At first, the volume of the union of hypervolumes is calculated for each hypervolume of the jth bootstrapped occupancy object as the ratio between the total number of random points and the number of random points of the ith hypervolume of the jth bootstrapped occupancy object, multiplied by the volume of the ith hypervolume of the jth bootstrapped occupancy object. This step results in a number of reconstructed volumes equal to the number of hypervolumes in the jth bootstrapped occupancy object. Reconstructed volumes are then compared among each other to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated with the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned. The volume of the unshared fraction is then calculated as the ratio between the number of random points of the unshared fraction and the total number of random points, multiplied by the volume of the union of hypervolumes. \cr
+When \code{relative = TRUE} relative instead of absolute volumes are returned. The relative volume is calculated as the ratio between the volume of the unshared fraction and the volume of the union of all the hypervolumes (or combination of hypervolumes when \code{method = "pairwise"}). The same approach described above is used to reconstruct the volume of the union of hypervolumes.
 }
 
 \value{
-A \code{data.frame} with bootrapped volumes or summary statistics of intersection for single groups or pairwise comparisons.
+A \code{data.frame} with bootstrapped volumes or summary statistics of the unshared fraction.
 }
 
 
 \seealso{
-\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \cr \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_union}},  \cr
-\code{\link{occupancy_to_unshared}} \code{\link{occupancy_filter}}
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}
+\code{\link{occupancy_to_unshared}}
 }
 
 \examples{

--- a/man/get_occupancy_volume_bootstrap.Rd
+++ b/man/get_occupancy_volume_bootstrap.Rd
@@ -6,7 +6,7 @@
 Extract the volume from occupancy bootstrap objects
 }
 \description{
-The function \code{get_occupancy_volume_bootstrap()} extract the volume from objects generated with \code{hypervolume_n_resample()}. It can provide raw values or summary statistics for both single groups or pairwise comparisons.
+The function \code{get_occupancy_volume_bootstrap()} extract the volume from objects generated with \code{hypervolume_n_occupancy_bootstrap()}. It provides raw values or summary statistics for both single hypervolumes or their pairwise comparisons.
 }
 \usage{
 get_occupancy_volume_bootstrap(path,
@@ -18,10 +18,10 @@ get_occupancy_volume_bootstrap(path,
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{path}{
-  A path to a directory containing bootstrapped hypervolumes generated with \code{get_occupancy_bootstrap_volume()}.
+  A path to a directory containing bootstrapped occupancy objects generated with \code{hypervolume_n_occupancy_bootstrap()}.
 }
   \item{method}{
-If \code{all} the function computes returns the volume of single bootstrapped hypervolumes. If \code{pairwise} returns the comparison among pairwise combination of hypervolumes.
+If \code{all} the function returns the volume of each bootstrapped hypervolume for each bootstrapped occupancy object in \code{path}. If \code{pairwise} returns the volume difference for each pairwise combination of hypervolumes within the bootstrapped occupancy objects found in \code{path}.
  }
   \item{res_type}{
   It can be \code{raw} or \code{pairwise}. See details.
@@ -30,19 +30,20 @@ If \code{all} the function computes returns the volume of single bootstrapped hy
   If \code{TRUE} it computes relative instead of absolute volumes.
 }
   \item{tol}{
-  Set the tolerance for reconstructing whole volume.
+  Set the tolerance for reconstructing whole volume. See details.
  }
 }
 \details{
-  The function \code{get_occupancy_volume_bootstrap()} returns the volume of bootstrapped hypervolumes if \code{res_type} is equal to \code{raw} and \code{method} to \code{all}. When \code{res_type} is equal to \code{summary} and method to \code{all} this function returns the mean volume as well as standard deviation, median, minimum, maximum and two quantiles of each group. These summary statistics are calculated for among groups pairwise comparisons when \code{res_type} is equal to \code{summary} and \code{method} to \code{pairwise}.
+The function \code{get_occupancy_volume_bootstrap()} returns the volume for each bootstrapped hypervolume if \code{res_type = "raw"} and \code{method = "all"}. When \code{res_type = "summary"} and \code{method = "all"} this function returns the mean volume as well as the standard deviation, median, minimum, maximum, 2.5\% and 97.5\% quantiles, skewness and kurtosis for each of hypervolume. The same summary statistics are calculated for the difference of volume for each pairwise combination of hypervolumes when \code{res_type = "summary"} and \code{method = "pairwise"}. \cr
+When \code{relative = TRUE} relative instead of absolute volumes are returned. The relative volume is calculated as the ratio between the volume of an hypervolume and the volume of the union of all the hypervolumes. The \code{get_occupancy_volume_bootstrap()} function attempts to reconstruct the volume of the union of all the hypervolumes from each bootstrapped hypervolume. At first, the volume of the union of hypervolumes is calculated for each hypervolume of the jth bootstrapped occupancy_object as the the ratio between the total number of random points and the number of random points of the ith hypervolume of the jth bootstrapped occupancy_object, multiplied by the volume of the ith hypervolume of the jth bootstrapped occupancy_object. This step results in a number of reconstructed volumes equal to the number of hypervolumes in the jth bootstrapped occupancy_object. Reconstructed volumes are then compared among each other to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated with the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned.
 }
+
 \value{
-A \code{data.frame} with bootrapped volumes or summary statistics for single groups or pairwise comparisons.
+A \code{data.frame} with bootstrapped volumes or summary statistics for single hypervolumes or their pairwise comparisons.
 }
 
 \seealso{
-\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \cr \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_intersection}},  \cr
-\code{\link{occupancy_to_union}} \code{\link{occupancy_filter}}
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}
 }
 
 \examples{

--- a/man/get_relative_volume.Rd
+++ b/man/get_relative_volume.Rd
@@ -5,30 +5,40 @@
 \title{
 Extract the relative volume
 }
+
 \description{
-Extract the relative volume from \code{hypervolume_n_occupancy()} \cr 
-or \code{hypervolume_n_occupancy_test()}.
+The function \code{get_relative_volume()} computes the relative volume from objects generated with the occupancy routine.
 }
+
 \usage{
 get_relative_volume(hv_list, tol = 1e-10)
 }
+
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{hv_list}{
-  A \code{Hypervolume} or \code{HypervolumeList} object generated with \cr
-  \code{hypervolume_n_occupancy()} or \code{hypervolume_n_occupancy_test()}.
+  A \code{Hypervolume} or \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()}, \code{hypervolume_n_occupancy_permute()}, \code{hypervolume_n_occupancy_test()}, \code{occupancy_to_union()}, \code{occupancy_to_intersection()}, \code{occupancy_to_unshared()}, or \code{occupancy_filter()}.
 }
   \item{tol}{
-Set the tolerance for reconstructing whole volume.
+Set the tolerance for reconstructing whole volume. See details.
  }
 }
+
 \details{
-This function tries to reconstruct the volume of the union of hypervolumes from the object. For some reasons,
-the reconstruction can fail. If the reconstruction fails, try to increase the tolerance or to check the accuracy of the \code{hypervolume_n_occupancy()} results.   
+The relative volume is calculated as the ratio between hypervolumes of an \code{HypervolumeList} and the volume resulting from the union of hypervolumes in the same \code{HypervolumeList}. Relative volumes can be calculated only for \code{HypervolumeList} generated with functions \code{hypervolume_n_occupancy()}, \code{hypervolume_n_occupancy_test()}, \code{hypervolume_n_occupancy_permute()}, \code{occupancy_to_union()}, \code{occupancy_to_ushared()}, \code{occupancy_to_intersection()} or \code{occupancy_filter()}. \cr
+The \code{get_relative_volume()} function attempts to reconstruct the volume of the union of hypervolumes from \code{hv_list}. At first, the volume of the union of hypervolumes is calculated for each hypervolume of \code{hv_list} as the the ratio between the total number of random points and the number of random points of the ith hypervolume of \code{hv_list}, multiplied by the volume of the ith hypervolume \code{hv_list}. This step results in a number of reconstructed volumes equal to the number of hypervolumes in \code{hv_list}. Reconstructed volumes are then compared to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated with the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned.
 }
+
 \value{
 A named numeric vector with the relative volume of each input hypervolume
 }
+
+\seealso{
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_permute}}, \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_union}},
+\code{\link{occupancy_to_unshared}}, \code{\link{occupancy_to_intersection}},
+\code{\link{occupancy_filter}}
+}
+
 
 \examples{
 \dontrun{

--- a/man/hypervolume_n_occupancy.Rd
+++ b/man/hypervolume_n_occupancy.Rd
@@ -40,10 +40,10 @@ hypervolume_n_occupancy_bootstrap(path,
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{hv_list}{
-An HypervolumeList.
+An \code{HypervolumeList}.
 }
   \item{classification}{
-A vector assigning each Hypervolume in the HypervolumeList to a group.
+A vector assigning each hypervolume in the \code{HypervolumeList} to a group.
 }
   \item{method}{
 Can be \code{subsample} or \code{box}. See details.
@@ -64,17 +64,16 @@ Numeric value; multiplicative factor applied to the critical distance for all in
 Check if data is hyperplanar.
 }
   \item{box_density}{
-Density of random point to fill the hyperbox when method is equal to \code{box}.
+Density of random points to fill the hyperbox when method is equal to \code{box}.
 }
   \item{thin}{
-Try to find a random points distribution more uniform than the current one. Intended to be used with
-\code{method = subsample}, but can be used with \code{method = box}. Can be slow, especially in high dimensions. See details.
+Take a subsample of random points to get a more uniform distribution of random points. Intended to be used with \code{method = "subsample"}, but can be used with \code{method = "box"} too. Can be slow, especially in high dimensions. See details.
 }
   \item{quant.thin}{
-Set quantile for using when \code{thin = TRUE} See details.
+Set quantile for using when \code{thin = TRUE}. See details.
 }
   \item{seed}{
-Set seed for random number generation. Useful for having reproducible results and with the use of \code{\link{find_optimal_occupancy_thin}}
+Set seed for random number generation. Useful for having reproducible results and with the use of \code{\link[=find_optimal_occupancy_thin]{find_optimal_occupancy_thin()}}
 }
   \item{print_log}{
 Save a log file with the volume of each input hypervolume, recomputed volume and the ratio between the original and recomputed hypervolumes. It works for \code{hypervolume_n_occupancy()} only.
@@ -89,35 +88,23 @@ File name; The function writes hypervolumes to file in "./Objects/<name>".
 
 }
 \details{
-Uses the inclusion test approach to count how many hypervolumes in each group includes random points. Counts range from 0 (no hypervolume contains a given random point), to the number of hypervolumes in a group (all the hypervolumes contains a given random point). A function \code{FUN}, usually \code{mean} or \code{sum}, is then applied. An hypervolume is then returned for each group and the occupancy stored in \code{@ValueAtRandomPoints}. IMPORTANT: random points with 
-\code{@ValueAtRandomPoints} equal to 0 are not removed to ease downstream calculation.  
-
-The computation is actually performed on a random sample from input hypervolumes, constraining each to have the same point density given by the minimum of the point density of each input hypervolume, and the point density calculated using the volumes of each input hypervolume divided by \code{num.points.max}.
-
-Because this algorithm is based on distances calculated between the distributions of random points, the critical distance (point density ^ (-1/n)) can be scaled by a user-specified factor to provide more or less liberal estimates (\code{distance_factor} greater than or less than 1).
-
-Two methods can be used for calculating the occupancy. The method \code{subsample} is based on a random sample of points from input hypervolumes. Each point is selected with a probability set to the inverse of the number of neighbour points calculated according to the critical distance. This method performs accurately when input hypervolumes have a low degree of overlap. The method \code{box} create a bounding box around the union of input hypervolumes. The bounding box is filled with points following a uniform distribution and with a density set with the argument \code{box_density}. A greater density provides more accurate results. The method \code{box_density} performs better than the method \code{subsample} in low dimensions, while in higher dimensions \code{box_density} become computationally inefficient as nearly all of the hyperbox sampling space will end up being empty and most of the points will be rejected.
-
-When \code{verbose = TRUE} the volume of each input hypervolume will be printed togheter with the recomputed volume and the ratio between the original and recomputed hypervolumes. Mean absolute error (MAE) and root mean square error (RMSE) is also provided as overall measures of the goodness of fit. A log file will be saved in the working directory with the information about the volume of input hypervolumes, the recomputed volume and the ratio between the original and recomputed hypervolumes.
-
-When \code{thin = TRUE} an algorithm is applied to try to make the distribtuion of random points more uniform. Moderate departures from uniform distribution can result from applying \cr
-\code{hypervolume_n_occupancy()} on hypervolumes with a high overlap degree. At first, the algorithm in \code{thin} calculates the distance from the neighboor points within the critical distance for each random point. The quantile (set with \code{quant.thin}) of these distances is taken and set as input for the next step. Random points are then subset so that the distance of a point to another is greater than the threshold distance.   
-
-The function \code{hypervolume_n_occupancy()} takes an hypervolume list as inut and returns an object of class \code{Hypervolume} or \code{HypervolumeList}. 
-
-The function \code{hypervolume_n_occupancy_bootstrap()} takes a path of bootstrapped hypervolumes generated with \code{hypervolume_n_resample()} as input. \cr
-\code{hypervolume_n_occupancy_bootstrap()} creates a directory called Objects in the current working directory if a directory of that name doesn't already exist. Returns an absolute path to directory with resampled hypervolumes. It automatically saves a log file with the volume of each input hypervolume, recomputed volume and the ratio between the original and recomputed hypervolumes. The log file is used with \cr
-\code{occupancy_bootstrap_gof()}.
-
+Uses the inclusion test approach to count how many hypervolumes include each random point. Counts range from 0 (no hypervolumes contain a given random point), to the number of hypervolumes in a group (all the hypervolumes contain a given random point). A function \code{FUN}, usually \code{mean} or \code{sum}, is then applied. A hypervolume is then returned for each group and the occupancy stored in \code{ValueAtRandomPoints}. IMPORTANT: random points with 
+\code{ValueAtRandomPoints} equal to 0 are not removed to ease downstream calculation. \cr
+When \code{method = "subsample"} the computation is performed on a random sample from input hypervolumes, constraining each to have the same point density given by the minimum of the point density of each input hypervolume and the point density calculated using the volumes of each input hypervolume divided by \code{num.points.max}. \cr
+Because this algorithm is based on distances calculated between the distributions of random points, the critical distance (point density ^ (-1/n)) can be scaled by a user-specified factor to provide more or less liberal estimates (\code{distance_factor} greater than or less than 1). \cr
+Two methods can be used for calculating the occupancy. The method \code{subsample} is based on a random sample of points from input hypervolumes. Each point is selected with a probability set to the inverse of the number of neighbour points calculated according to the critical distance. This method performs accurately when input hypervolumes have a low degree of overlap. The method \code{box} create a bounding box around the union of input hypervolumes. The bounding box is filled with points following a uniform distribution and with a density set with the argument \code{box_density}. A greater density usually provides more accurate results. The method \code{box} performs better than the method \code{subsample} in low dimensions, while in higher dimensions the method \code{box} become computationally inefficient as nearly all of the hyperbox sampling space will end up being empty and most of the points will be rejected. \cr
+When \code{verbose = TRUE} the volume of each input hypervolume will be printed to screen togheter with the recomputed volume and the ratio between the original and recomputed hypervolumes. Mean absolute error (MAE) and root mean square error (RMSE) are also provided as overall measures of the goodness of fit. A log file will be saved in the working directory with the information about the volume of input hypervolumes, the recomputed volume and the ratio between the original and recomputed hypervolumes. \cr
+When \code{thin = TRUE} an algorithm is applied to try to make the distribution of random points more uniform. Moderate departures from uniform distribution can in fact result from applying \code{hypervolume_n_occupancy()} on hypervolumes with a high overlap degree. At first, the algorithm in \code{thin} calculates the minimum distance from the neighboor points within the critical distance for each random point. A quantile (set with \code{quant.thin}) of these distances is taken and set as the threshold distance. Random points are then subset so that the distance of a point to another is greater than the threshold distance. \cr
+The function \code{hypervolume_n_occupancy_bootstrap()} takes a path of bootstrapped hypervolumes generated with \code{hypervolume_n_resample()} as input. It creates a directory called Objects in the current working directory if a directory of that name doesn't already exist where storing occupancy objects. The function \code{hypervolume_n_occupancy_bootstrap()} returns the absolute path to the directory with bootstrapped hypervolumes. It automatically saves a log file with the volume of each input hypervolume, the recomputed volume and the ratio between the original and recomputed hypervolumes. The log file is used with \code{occupancy_bootstrap_gof()}.
 }
 
 \seealso{
-\code{\link{find_optimal_occupancy_thin}}
+\code{\link{find_optimal_occupancy_thin}}, \code{\link{occupancy_bootstrap_gof}}
 }
 
 
 \value{
-\code{hypervolume_n_occupancy()} returns an HypervolumeList whose number of elements equals the number of groups in \code{classification}. \code{hypervolume_n_occupancy_bootstrap()} returns a string containing an absolute path equivalent to ./Objects/<name>.
+\code{hypervolume_n_occupancy()} returns a \code{Hypervolume} or \code{HypervolumeList} whose number of hypervolumes equals the number of groups in \code{classification}. \code{hypervolume_n_occupancy_bootstrap()} returns a string containing an absolute path equivalent to ./Objects/<name>.
 }
 
 \examples{

--- a/man/hypervolume_n_occupancy_permute.Rd
+++ b/man/hypervolume_n_occupancy_permute.Rd
@@ -5,52 +5,52 @@
 Hypervolumes through permuting labels of n pairwise groups of hypervolumes
 }
 \description{
-Permute labels of an \code{hypervolume_n_occupancy()} object and calculate \code{hypervolume_n_occupancy()} for the permuted objects. This function is meant for taking a sample of all permutations and does not guarantee that permutations are not repeated. Newly generated hypervolume objects are written to file. This function is to be used within the n_occupancy routine.
+Permute labels of an \code{hypervolume_n_occupancy()} object and calculate \code{hypervolume_n_occupancy()} for the permuted objects. This function is meant for taking a sample of all permutations and does not guarantee that permutations are not repeated. Newly generated hypervolume objects are written to file. This function is to be used within the occupancy routine.
 }
 \usage{
 hypervolume_n_occupancy_permute(name, 
-  hv_list1,
-  hv_list2,
-  verbose = TRUE,
-  n = 9,
-  cores = 1)
+                                hv_list1,
+                                hv_list2,
+                                verbose = TRUE,
+                                n = 9,
+                                cores = 1)
 }
 \arguments{
   \item{name}{
 File name; The function writes hypervolumes to file in ./Objects/<name>
 }
   \item{hv_list1}{
-An hypervolume list generated with \code{hypervolume_n_occupancy()}
+An hypervolume list generated with \code{hypervolume_n_occupancy()}.
 }
   \item{hv_list2}{
-The hypervolume list used to generate hv_list1
+The hypervolume list used to generate \code{hv_list1}.
 }
   \item{verbose}{
-Logical value; If function is being run sequentially, outputs progress bar in console.
+Logical value; outputs progress bar in console.
 }
   \item{n}{
-number of permutations to take
+Number of permutations to take.
 }
   \item{cores}{
-Number of logical cores to use while generating permuted hypervolumes. If parallel backend already registered to \code{doParallel}, function will use that backend and ignore the argument in cores.
+Number of logical cores to use while generating permuted hypervolumes. If parallel backend already registered to \code{doParallel}, function will use that backend and ignore the argument in \code{cores}.
 }
 
 }
 \details{
-\code{hypervolume_n_occupancy_permute()} creates a directory called Objects in the current working directory if a directory of that name doesn't already exist. Within this directory, it creates a directory for each pairwise combinations of elements within hv_list1. Group labels are permuted and a new HypervolumeList is saved as a rds file for each pairwise combination. IMPORTANT: only group labels are permuted, random points are kept fixed and will be the same across all the permuted hypervolumes. 
+\code{hypervolume_n_occupancy_permute()} creates a directory called Objects in the current working directory if a directory of that name doesn't already exist. Within this directory, it creates a directory for each pairwise combinations of elements within \code{hv_list1}. Group labels are permuted and a new \code{HypervolumeList} is saved as a rds file for each pairwise combination. IMPORTANT: only group labels are permuted, random points are kept fixed and will be the same across all the permuted hypervolumes. 
 
-Use \code{hypervolume_n_occupancy_permute} when generating null distribution of test statistics. \code{hypervolume_n_occupancy_test()} takes in a \code{hypervolume_n_occupuancy_permute()} filepath output.
+\code{hypervolume_n_occupancy_test()} takes in a \code{hypervolume_n_occupuancy_permute()} filepath output.
 
 It is also possible to access the hypervolumes by using readRDS to read the hypervolume objects in one by one.
 }
 
 
 \section{Warning}{
-  \code{hypervolume_n_occupancy_permute()} requires a lot of disk space especially when building occupancy hypervolumes with \code{method = box}. Try with a small number of replications and check the folder Objects for memory usage before to proceed.
+  \code{hypervolume_n_occupancy_permute()} requires a lot of disk space especially when building occupancy hypervolumes with \code{method = "box"}. Try with a small number of replications and check the folder Objects for memory usage before to proceed.
 }
 
 \value{
-returns a string containing an absolute path equivalent to ./Objects/<name>
+Returns a string containing an absolute path equivalent to ./Objects/<name>
 }
 \seealso{
 \code{\link{hypervolume_n_occupancy}}

--- a/man/hypervolume_n_occupancy_test.Rd
+++ b/man/hypervolume_n_occupancy_test.Rd
@@ -5,47 +5,46 @@
 Significance of random points occupancy
 }
 \description{
-Calculates overlap for two hypervolumes.
+The function \code{hypervolume_n_occupancy_test()} calculates the significance of the difference between occupancy values for each random point and for all the pairwise combinations of groups in objects generated with \code{hypervolume_n_occupancy()} and \code{hypervolume_n_occupancy_permute()}.
 }
 \usage{
 hypervolume_n_occupancy_test(observed,
-  path,
-  alternative = "two_sided",
-  significance = 0.05,
-  cores = 1, 
-  p_adjust = "none",
-  multi_comp_type = "pairwise")
+                             path,
+                             alternative = "two_sided",
+                             significance = 0.05,
+                             cores = 1, 
+                             p_adjust = "none",
+                             multi_comp_type = "pairwise")
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{observed}{
-An HypervolumeList generated from \code{\link{hypervolume_n_occupancy}}.
+An \code{HypervolumeList} generated from \code{\link[=hypervolume_n_occupancy]{hypervolume_n_occupancy()}}.
 }
   \item{path}{
-A path to a directory of permuted hypervolumes generated with \cr
-\code{\link{hypervolume_n_occupancy_permute}}.
+A path to a directory of permuted hypervolumes generated with \code{\link[=hypervolume_n_occupancy_permute]{hypervolume_n_occupancy_permute()}}.
 }
   \item{alternative}{
-Alternative hypothesis, can be one of \code{two_sided}, \code{more}, \code{less} or \code{more_less}.
+Alternative hypothesis, can be one of \code{two_sided}, \code{more} or \code{less}.
 }
   \item{significance}{
-Occupancy values lower than the this threshold will be retained.
+Significance values lower than this threshold will be retained.
 }
   \item{cores}{
-Number of logical cores to use while generating permuted hypervolumes. If parallel backend already registered to \code{doParallel}, function will use that backend and ignore the argument in cores.
+Number of logical cores to use while generating permuted hypervolumes. If parallel backend already registered to \code{doParallel}, function will use that backend and ignore the argument in \code{cores}.
 }
   \item{p_adjust}{
-Method of correction for multiple comparisons, set to \code{none} by default. Otherwise look at \code{\link{p.adjust}} for alternative
+Method of correction for multiple comparisons, set to \code{none} by default. Otherwise look at \code{p.adjust} of the \code{stats} package for alternatives.
 }
   \item{multi_comp_type}{
-Type of multiple comparison. Can be \code{pairwise}, for which the number of comparison is set to the length of ValueAtRandomPoint, or \code{all},  for which the number of comparison is set to the length of ValueAtRandomPoint times the number of comparisons.
+Type of multiple comparison. Can be \code{pairwise}, for which the number of comparisons is set to the length of \code{ValueAtRandomPoints}, \code{all},  for which the number of comparisons is set to the length of \code{ValueAtRandomPoints} times the number of groups, or \code{none}.
 }
 }
 \details{
-The observed difference between ValueAtRandomPoints of two groups is compared against null expectations generated with \code{hypervolume_n_occupancy_permute}. 
+The observed difference between \code{ValueAtRandomPoints} of two groups is compared against null expectations generated with \code{hypervolume_n_occupancy_permute()}. 
 }
 \value{
-An HypervolumeList with length equal to the number of pairwise combination of the observed HypervolumeList elements. ValueAtRandomPoints are calculated as the difference between the ValueAtRandomPoints of the first and the second group for each pairwise combinations. Only significant values are retained according to CI.
+An \code{HypervolumeList} of length equal to the number of pairwise combinations of the observed \code{HypervolumeList} elements. \code{ValueAtRandomPoints} are calculated as the difference between the \code{ValueAtRandomPoints} of the first and the second group for each pairwise combination. Only significant values are retained according to \code{significance}.
 }
 
 \examples{

--- a/man/hypervolume_n_resample.Rd
+++ b/man/hypervolume_n_resample.Rd
@@ -2,7 +2,7 @@
 \alias{hypervolume_n_resample}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
- Bootstrap n hypervolumes
+Bootstrap n hypervolumes
 }
 \description{
 The function \code{hypervolume_n_resample()} generates n hypervolumes using data bootstrapped from original data of the input hypervolumes.
@@ -33,7 +33,7 @@ Used for every method.
 Number of points in each resample. If the input is \code{sample_size}, then the same number of points as the original sample is used.
 }
   \item{cores}{
-Number of logical cores to use while generating bootstraped hypervolumes. If parallel backend already registered to \code{doParallel}, function will use that backend and ignore the argument in cores.
+Number of logical cores to use while generating bootstraped hypervolumes. If parallel backend already registered to \code{doParallel}, function will use that backend and ignore the argument in \code{cores}.
 }
   \item{verbose}{
 Logical value; If function is being run sequentially, outputs progress bar in console.
@@ -47,13 +47,14 @@ Returns a string containing an absolute path equivalent to ./Objects/<name>
 }
 
 \details{
-\code{hypervolume_n_resample()} creates a directory called Objects in the current working directory if a directory of that name doesn't already exist. Returns an absolute path to directory with resampled hypervolumes. rds files are stored in different file structures depending on which method is called.
-
-It is possible to access the hypervolumes by using readRDS to read the hypervolume objects in one by one.
-
+\code{hypervolume_n_resample()} creates a directory called Objects in the current working directory if a directory of that name doesn't already exist. A directory is then created for each hypervolume in \code{hv_list}. Returns an absolute path to directory with resampled hypervolumes. \cr
+It is possible to access the hypervolumes by using readRDS to read the hypervolume objects one by one. \cr
 The resampled hypervolumes are generated using the same parameters used to generate the input hypervolume. The only exception is that the bandwidth is re-estimated if \code{method = "gaussian"} or \code{method = "box"}. See \code{\link{copy_param_hypervolume}} for more details.
 }
 
+\seealso{
+\code{\link{hypervolume_n_occupancy_bootstrap}}
+}
 
 \examples{
 \dontrun{

--- a/man/hypervolume_to_data_frame.Rd
+++ b/man/hypervolume_to_data_frame.Rd
@@ -16,16 +16,11 @@ hypervolume_to_data_frame(hv, remove_zeroes = TRUE)
 A \code{Hypervolume} or \code{HypervolumeList}.
 }
   \item{remove_zeroes}{
-Remove zeroes from ValuesAtRandomPoints. See Details for further information. It works when construction methods are \code{n_occupancy}, \code{n_occupancy_test}, \code{occupancy_to_union}, \code{occupancy_to_intersection} and \cr
-\code{occupancy_to_unshared}, otherwise ignored. 
+Remove zeroes from \code{ValuesAtRandomPoints}. See Details for further information. It works for \code{hypervolume_n_occupancy()}, \code{hypervolume_n_occupancy_test()}, \code{occupancy_to_union()}, \code{occupancy_to_intersection()} and \code{occupancy_to_unshared()}, otherwise ignored. 
 }
 }
 \details{
-Zero values are generated
-during the occupancy routine when a random point is included 
-in some group of hypervolumes but not in others. A tipical usage of
-\code{hypervolume_to_data_frame()} with objects generated with the occupancy routine
-should remove zeroes.
+Zero values are generated during the occupancy routine when a random point is included in some groups of hypervolumes but not in others. A tipical usage of \code{hypervolume_to_data_frame()} with objects generated with the occupancy routine should remove zeroes.
 }
 \value{
 A \code{data.frame}.

--- a/man/occupancy_bootstrap_gof.Rd
+++ b/man/occupancy_bootstrap_gof.Rd
@@ -6,27 +6,26 @@
  Goodness of fit metrics for bootstrapped occupancy objects
 }
 \description{
-The \code{occupancy_bootstrap_gof()} function calculates goodness of fit metrics for objects generated with  \code{hypervolume_n_occupancy_bootstrap()}.
+The \code{occupancy_bootstrap_gof()} function calculates goodness of fit metrics for objects generated with \code{hypervolume_n_occupancy_bootstrap()}.
 }
 \usage{
-  occupancy_bootstrap_gof(path, FUN)
+occupancy_bootstrap_gof(path, FUN)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{path}{
-  A path to a directory of bootstrapped hypervolumes generated with \cr
-  \code{hypervolume_n_occupancy_bootstrap()}.
+  A path to a directory of bootstrapped hypervolumes generated with \code{hypervolume_n_occupancy_bootstrap()}.
 }
   \item{FUN}{
-Function to calculate the goodness of fit. It can be \code{mae} for mean absolute error, \code{rmse} for root mean square error or a function provided by the user.  
+Function to calculate the goodness of fit. It can be \code{mae} for the mean absolute error, \code{rmse} for the root mean square error or a function provided by the user.  
  }
 }
 \details{
-Goodness of fit metrics are calculated on the difference between input and recomputed volumes for each bootstrapped element (set with n in \code{hypervolume_n_resample()}). \cr 
-See \code{hypervolume_n_occupancy()} for details on the meaning of input and recomputed hypervolumes. 
+Goodness of fit metrics are calculated on the difference between input and recomputed volumes for each bootstrapped element (set with \code{n} in \code{hypervolume_n_resample()}). See \code{\link[=hypervolume_n_occupancy]{hypervolume_n_occupancy()}} for details on the meaning of input and recomputed hypervolumes. 
 }
+
 \value{
-A one row \code{data.frame} reporting mean, standard deviation, minimum, maximum, median and 4 quantile values. 
+A one row \code{data.frame} reporting mean, standard deviation, minimum, maximum, median, 2.5\%, 25\%, 75\% ans 97.5\% quantiles. 
 }
 
 \examples{

--- a/man/occupancy_filter.Rd
+++ b/man/occupancy_filter.Rd
@@ -6,17 +6,15 @@
  Subset occupancy hypervolumes
 }
 \description{
-The \code{occupancy_filter()} function is used to subset an hypervolume generated with \cr
-\code{hypervolume_n_occupancy()} or \code{hypervolume_n_occupancy_test()}.
+The \code{occupancy_filter()} function is used to subset an hypervolume generated with \code{hypervolume_n_occupancy()} or \code{hypervolume_n_occupancy_test()}.
 }
 \usage{
-  occupancy_filter(hv, operator = NULL, filter = NULL, tol = 1e-10)
+occupancy_filter(hv, operator = NULL, filter = NULL, tol = 1e-10)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{hv}{
-  A \code{Hypervolume} or \code{HypervolumeList} object generated with  \cr
-  \code{hypervolume_n_occupancy()} or \code{hypervolume_n_occupancy_test()}.
+  A \code{Hypervolume} or \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()} or \code{hypervolume_n_occupancy_test()}.
 }
   \item{operator}{
 Binary operator which allow the comparison.
@@ -25,11 +23,14 @@ Binary operator which allow the comparison.
 Threshold value to perform the operation.
  }
   \item{tol}{
-Set the tolerance for reconstructing whole volume.
+Set the tolerance for reconstructing whole volume. See details.
  }
 }
 \details{
-This function set the occupancy value based on the user-provided operation. Volume of the hypervolumes are changed accordingly.  
+The \code{occupancy_filter()} function set the occupancy values to 0 based on the user-provided operation. Volume of the hypervolumes are changed accordingly.\cr
+When \code{hv} is an \code{HypervolumeList}, the \code{occupancy_filter()} function attempts to reconstruct the volume of the union of hypervolumes from \code{hv_list}. At first, the volume of the union of hypervolumes is calculated for each element of \code{hv} as the the ratio between the total number of random points and the number of random points of the ith element of \code{hv}, multiplied by the volume of the ith element \code{hv}. This step results in a number of reconstructed volumes equal to the number of hypervolumes in the jth bootstrapped occupancy_object. Reconstructed volumes are then compared among each other to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated with the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned.
+
+
 }
 \value{
 A \code{\link{Hypervolume-class}} or \code{\link{HypervolumeList-class}} object.

--- a/man/occupancy_to_intersection.Rd
+++ b/man/occupancy_to_intersection.Rd
@@ -6,34 +6,41 @@
  Get the intersection of an occupancy object
 }
 \description{
-The \code{occupancy_to_intersection()} function is used to get the intersection in an object generated with \code{hypervolume_n_occupancy()}.
+The \code{occupancy_to_intersection()} function is used to get the intersection of hypervolumes of an object generated with the occupancy routine.
 }
 \usage{
-  occupancy_to_intersection(hv_list, method = "all", m = 2, tol = 1e-10)
+occupancy_to_intersection(hv_list, method = "all", m = 2, tol = 1e-10)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{hv_list}{
-  A \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()}.
+A \code{HypervolumeList} generated with \code{hypervolume_n_occupancy()},  \code{hypervolume_n_occupancy_test()}, \code{occupancy_to_union()}, \code{occupancy_to_unshared()} or \code{occupancy_filter()}.
 }
   \item{method}{
-If \code{all} the function compares the target hypervolume with all the hypervolume in \code{hv}. If \code{n_wise} it computes the intersection of each n_wise combination of hypervolumes in \code{hv}.
+If \code{all} compute the intersection among all the hypervolumes in \code{hv_list}. If \code{n_wise} compute the intersection for each n_wise combination of hypervolumes in \code{hv_list}.
  }
   \item{m}{
 Number of elements to choose. Default to 2 (pairwise comparisons). This argument is ignored when \code{method} is set to \code{all}.
  }
   \item{tol}{
-Set the tolerance for reconstructing whole volume.
+Set the tolerance for reconstructing whole volume. See details.
  }
 }
+
+\details{
+The \code{occupancy_to_intersection()} function takes as input a \code{HypervolumeList} generated with an occupancy function (check \code{See Also}) and returns a \code{Hypervolume} or \code{HypervolumeList} depending on \code{method}. When \code{method = "all"} the \code{occupancy_to_intersection()} function returns a \code{Hypervolume} representing the intersection of all the hypervolumes in \code{hv_list}. When \code{method = "n_wise"} a \code{HypervolumeList} in which each hypervolume represent the intersection of a combination of the hypervolumes in \code{hv_list} is returned. The number of hypervolumes for each combination is set with the argument \code{m}. Argument \code{m} can not be higher than the number of hypervolumes in \code{hv_list} and lower than 2. \cr
+The \code{occupancy_to_intersection()} function attempts to reconstruct the volume of the intersection from the \code{hv_list} provided by the user. At first, the volume of the union of hypervolumes is calculated for each hypervolume in \code{hv_list} as the the ratio between the total number of random points and the number of random points of the ith hypervolume of \code{hv_list}, multiplied by the volume of the ith hypervolume of \code{hv_list}. This step results in a number of reconstructed volumes equal to the number of hypervolumes in the jth bootstrapped occupancy_object. Reconstructed volumes are then compared among each other to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated with the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned. The volume of the intersection is then calculated as the ratio between the number of random points of the intersection and the total number of random points, multiplied by the volume of the union of hypervolumes.
+}
+
+
 
 \value{
 A \code{\link{Hypervolume-class}} or \code{\link{HypervolumeList-class}} object.
 }
 
 \seealso{
-\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \cr \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_union}}, \cr
-\code{\link{occupancy_to_unshared}} \code{\link{occupancy_filter}}
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_union}},
+\code{\link{occupancy_to_unshared}}, \code{\link{occupancy_filter}}
 }
 
 \examples{

--- a/man/occupancy_to_union.Rd
+++ b/man/occupancy_to_union.Rd
@@ -6,34 +6,34 @@
  Union of hypervolumes from an occupancy object
 }
 \description{
-The \code{occupancy_to_union()} function is used to get the union of all the hypervolumes or of n_wise combinations of them generated with \code{hypervolume_n_occupancy()}.
+The \code{occupancy_to_union()} function is used to get the union of hypervolumes of an object generated with \code{hypervolume_n_occupancy()}.
 }
 \usage{
-  occupancy_to_union(hv_list, method = "all", m = 2, tol = 1e-10)
+occupancy_to_union(hv_list, method = "all", m = 2, tol = 1e-10)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{hv_list}{
-  A \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()} or \code{hypervolume_n_occupancy_test()}.
+A \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()}, \code{hypervolume_n_occupancy_test()}, \code{occupancy_to_intersection()}, \code{occupancy_to_unshared()} or \code{occupancy_filter()}.
 }
   \item{method}{
-If \code{all} the function performs the union of all the hypervolumes in \code{hv_list}. If \code{n_wise} it compute the union of each n_wise combination of hypervolumes in \code{hv}.
+If \code{all} compute the union of all the hypervolumes in \code{hv_list}. If \code{n_wise} compute of the union for each n_wise combination of hypervolumes in \code{hv_list}.
  }
    \item{m}{
 Number of elements to choose. Default to 2 (pairwise comparisons). This argument is ignored when \code{method} is set to \code{all}.
  }
   \item{tol}{
-Set the tolerance for reconstructing whole volume.
+Set the tolerance for reconstructing whole volume. See details.
  }
 }
+
 \details{
-Unshared fraction is the fraction of the hypervolume not shared with other hypervolumes.
+The \code{occupancy_to_union()} function takes as input a \code{HypervolumeList} generated with an occupancy function (check \code{See Also}) and returns a \code{Hypervolume} or \code{HypervolumeList} depending on \code{method}. When \code{method = "all"} the \code{occupancy_to_union()} function returns a \code{Hypervolume} representing the union of all the hypervolumes in \code{hv_list}. When \code{method = "n_wise"} a \code{HypervolumeList} in which each hypervolume represent the union of a combination of the hypervolumes in \code{hv_list} is returned. The number of hypervolumes for each combination is set with the argument \code{m}. Argument \code{m} can not be higher than the number of hypervolumes in \code{hv_list} and lower than 2. \cr
+The \code{occupancy_to_union()} function attempts to reconstruct the volume of the union from the \code{hv_list} provided by the user. For each hypervolume in \code{hv_list}, it calculates the volume of the union as the ratio between the total number of random points and the number of random points of the ith hypervolume of \code{hv_list}, multiplied by the volume of the ith hypervolume of \code{hv_list}. This step results in a number of reconstructed volumes equal to the number of hypervolumes in the jth bootstrapped occupancy_object. Reconstructed volumes are then compared among each other to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated with the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned.   
 }
 
 \seealso{
-\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \cr
-\code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_intersection}}, \cr
-\code{\link{occupancy_to_unshared}} \code{\link{occupancy_filter}}
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_intersection}}, \code{\link{occupancy_to_unshared}}, \code{\link{occupancy_filter}}
 }
 
 

--- a/man/occupancy_to_unshared.Rd
+++ b/man/occupancy_to_unshared.Rd
@@ -6,33 +6,35 @@
  Unshared fraction from an occupancy object
 }
 \description{
-The \code{occupancy_to_unshared()} function is used to get the unshared fraction of each hypervolumes in an object generated with \code{hypervolume_n_occupancy()}.
+The \code{occupancy_to_unshared()} function is used to get the unshared fraction of hypervolumes of an object generated with the occupancy routine.
 }
 \usage{
-  occupancy_to_unshared(hv_list, method = "all", tol = 1e-10)
+occupancy_to_unshared(hv_list, method = "all", tol = 1e-10)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{hv_list}{
-  A \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()}.
+  A \code{HypervolumeList} object generated with \code{hypervolume_n_occupancy()},  \code{hypervolume_n_occupancy_test()}, \code{occupancy_to_union()}, \code{occupancy_to_intersection()} or \code{occupancy_filter}.
 }
   \item{method}{
-If \code{all} the function compares the target hypervolume with all the hypervolume in \code{hv_list}. If \code{pairwise} it compute the unshared fraction for each pairwise combination of hypervolumes in \code{hv}.
+If \code{all} compute the unshared fraction of each hypervolume in \code{hv_list}. If \code{pairwise} compute the unshared fraction for each pairwise combination of hypervolumes in \code{hv_list}.
  }
   \item{tol}{
-Set the tolerance for reconstructing whole volume.
+Set the tolerance for reconstructing whole volume. See details.
  }
 }
 \details{
-Unshared fraction is the fraction of the hypervolume not shared with other hypervolumes.
+Unshared fraction is the fraction of the hypervolume not shared with other hypervolumes. It is calculated from occupancy objects only (check \code{See Also}). When \code{method = "all"} a \code{HypervolumeList} containing the unshared fraction of each hypervolume is returned. When \code{method = "pairwise"} an \code{HypervolumeList} containing the unshared fraction of the pairwise combination of hypervolumes is returned. Hypervolumes generated when \code{method = "pairwise"} include the unshared fraction of both hypervolumes under comparison. The first of the two hypervolumes is assigned with  \code{ValueAtRandomPoints} equal to 1 while, the second is assigned with \code{ValueAtRandomPoints} equal to -1. This is useful when used in combination with \code{occupancy_filter()} or \code{hypervolume_to_data_frame()}. \cr
+The \code{occupancy_to_unshared()} function attempts to reconstruct the volume of the unshared fraction from the \code{hv_list} provided by the user. At first, the volume of the union of hypervolumes is calculated for each hypervolume in \code{hv_list} as the the ratio between the total number of random points and the number of random points of the ith hypervolume of \code{hv_list}, multiplied by the volume of the ith hypervolume of \code{hv_list}. This step results in a number of reconstructed volumes equal to the number of hypervolumes in the jth bootstrapped occupancy_object. Reconstructed volumes are then compared among each other to ensure the consistency of the reconstruction. To do this, the distance among reconstructed volumes is calculated with the \code{dist()} function of the \code{stats} package. If at least one of the distances is greater than \code{tol} the computation is stopped and some suggestions are returned. The volume of the unshared fraction is then calculated as the ratio between the number of random points of the unshared fraction and the total number of random points, multiplied by the volume of the union of hypervolumes.
 }
+
 \value{
 A \code{\link{Hypervolume-class}} or \code{\link{HypervolumeList-class}} object.
 }
 
 \seealso{
-\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_bootstrap}}, \cr \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_intersection}}, \cr
-\code{\link{occupancy_to_union}} \code{\link{occupancy_filter}}
+\code{\link{hypervolume_n_occupancy}}, \code{\link{hypervolume_n_occupancy_test}}, \code{\link{occupancy_to_intersection}},
+\code{\link{occupancy_to_union}}, \code{\link{occupancy_filter}}
 }
 
 \examples{


### PR DESCRIPTION
Here a new bunch of improvements:
1. Help files are now more informative and curated. I hope they are ok now;
2. I replaced `class ==` with `inherits` each time I found one; 
3. I implemented `on.exit()` when using parallel computing or when restoring seed;
4. Minor fixes to the code;
5. I slighlty changed `get_centroid` code, now it throws a warning when provided with an occupancy object.

I did nearly 2000 lines of code for testing. I hope to have covered major issues that can happen in real case analysis.
I checked the package within RStudio with the option `--as-cran`. I received two notes:
1. Imports includes 22 non-default packages...
2. Information on .o files for x64 is not available...

As always, ready to fix problems.
Cheers,
Alex

